### PR TITLE
Validate community string

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -391,9 +391,9 @@ Agent.prototype._process_req = function _process_req(req) {
 	// Check for a valid community string. If it doesn't match, we just return.
 	// This will make the request time out on the requesters side giving away no more information then that
 	const reqCommunity = req.community.toString('utf-8');
-    if (this.agentCommunity !== reqCommunity) {
-        return;
-    }
+	if (this.agentCommunity !== reqCommunity) {
+		return;
+	}
 
 	rsp = message.createMessage({ version: req.version,
 	    community: req.community });

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -213,7 +213,6 @@ Agent.prototype._do_getset = function _do_getset(req, rsp) {
 			if (++ndone == nvb)
 				self._transmit_response(req._conn_recv, rsp);
 		};
-
 		handler.forEach(function (h) {
 			h(prq);
 		});

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -106,6 +106,7 @@ Agent(options)
 	this._dtrace.enable();
 
 	this._mib = new MIB();
+	this.agentCommunity = options.community;
 }
 util.inherits(Agent, Listener);
 
@@ -212,6 +213,7 @@ Agent.prototype._do_getset = function _do_getset(req, rsp) {
 			if (++ndone == nvb)
 				self._transmit_response(req._conn_recv, rsp);
 		};
+
 		handler.forEach(function (h) {
 			h(prq);
 		});
@@ -387,7 +389,12 @@ Agent.prototype._process_req = function _process_req(req) {
 
 	assert.ok(req.version >= 0 && req.version <= 1);
 
-	/* XXX check community here */
+	// Check for a valid community string. If it doesn't match, we just return.
+	// This will make the request time out on the requesters side giving away no more information then that
+	const reqCommunity = req.community.toString('utf-8');
+    if (this.agentCommunity !== reqCommunity) {
+        return;
+    }
 
 	rsp = message.createMessage({ version: req.version,
 	    community: req.community });

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -389,7 +389,7 @@ Agent.prototype._process_req = function _process_req(req) {
 	assert.ok(req.version >= 0 && req.version <= 1);
 
 	// Check for a valid community string. If it doesn't match, we just return.
-	// This will make the request time out on the requesters side giving away no more information then that
+	// This will make the request time out on the requesters side giving away no more information than that
 	const reqCommunity = req.community.toString('utf-8');
 	if (this.agentCommunity !== reqCommunity) {
 		return;


### PR DESCRIPTION
Currently the master branch responds to SNMP Get requests even when the community string does not match:
<img width="546" height="46" alt="image" src="https://github.com/user-attachments/assets/3a024a66-9af4-4b02-9bcf-f63ebb505371" />

This PR adds a simple check ensuring that the agent only responds when the request and configured community strings matches.